### PR TITLE
Concurrent sort with block

### DIFF
--- a/lib/concurrent_sort.rb
+++ b/lib/concurrent_sort.rb
@@ -6,13 +6,16 @@ module ConcurrentSort
   FAN_OUT = 200
   MIN = 1000
 
-  def stream_sort
+  def stream_sort; end
 
-  end
-
+  # Optional block: if passed, must implement a comparison between
+  # a and b and return an integer less than 0 when b follows a, 0 when a
+  # and b are equivalent, or an integer greater than 0 when a follows b.
+  #
+  # See: https://ruby-doc.org/core-2.5.0/Array.html#method-i-sort
   def sort(data)
     result_buf = []
-    MergeSortConcurrent.new(FAN_OUT, MIN, data, result_buf).sort
+    MergeSortConcurrent.new(FAN_OUT, MIN, data, result_buf, block_given? ? Proc.new : nil).sort
     result_buf
   end
 end

--- a/lib/sort_worker.rb
+++ b/lib/sort_worker.rb
@@ -6,10 +6,9 @@ class SortWorker
   end
 
   def sort
-    @data.sort!
+    block_given? ? @data.sort!(&Proc.new) : @data.sort!
     @data.each do |e|
       @result_buf << e
     end
   end
-
 end

--- a/test/merge_sort_test.rb
+++ b/test/merge_sort_test.rb
@@ -1,12 +1,12 @@
 require 'test/unit'
 require_relative '../lib/concurrent_sort'
+require_relative 'utils/car'
 
 class MergeSortTest < Test::Unit::TestCase
-
   TEST_ITER = 10
   MIN_VAL = -10_000
   MAX_VAL = 10_000
-  MAX_LEN = 10_000
+  MAX_LEN = 100_000
 
   def setup; end
 
@@ -15,21 +15,27 @@ class MergeSortTest < Test::Unit::TestCase
   def assert_invariants; end
 
   def assert_sorted(arr)
-    (0...arr.length-1).each {|i| yield(arr[i], arr[i + 1])}
+    (0...arr.length - 1).each {|i| yield(arr[i], arr[i + 1])}
   end
 
-  def rand_array(size: rand(1..MAX_LEN), range: MIN_VAL..MAX_VAL)
-    Array.new(size) {rand(range)}
+  # Generate elements of any type with block
+  def rand_array(size: rand(1..MAX_LEN))
+    Array.new(size) {yield}
+  end
+
+  def rand_int_array(size: rand(1..MAX_LEN), range: MIN_VAL..MAX_VAL)
+    rand_array(size: size) {rand(range)}
   end
 
   def test_stream_sort; end
 
   def test_sort
     (0..TEST_ITER).each do
-      arr = rand_array
+      arr = rand_int_array
 
       # Preconditions
       begin
+        arr.each {|el| el.is_a?(Comparable)}
       end
 
       sorted_arr = ConcurrentSort.sort(arr)
@@ -37,6 +43,42 @@ class MergeSortTest < Test::Unit::TestCase
       # Postconditions
       begin
         assert_sorted(sorted_arr) {|first, second| assert_true(first <= second, "Array not sorted: failed #{first} is not <= #{second}")}
+      end
+    end
+  end
+
+  def test_sort_block
+    (0..TEST_ITER).each do
+      arr = rand_int_array
+
+      # Preconditions
+      begin
+        arr.each {|el| el.is_a?(Comparable)}
+      end
+
+      sorted_arr = ConcurrentSort.sort(arr) {|first, second| -(first <=> second)}
+
+      # Postconditions
+      begin
+        assert_sorted(sorted_arr) {|first, second| assert_true(first >= second, "Array not sorted: failed #{first} is not >= #{second}")}
+      end
+    end
+  end
+
+  def test_sort_custom_obj
+    (0..TEST_ITER).each do
+      arr = rand_array {Car.new}
+
+      # Preconditions
+      begin
+        arr.each {|el| el.is_a?(Comparable)}
+      end
+
+      sorted_arr = ConcurrentSort.sort(arr)
+
+      # Postconditions
+      begin
+        assert_sorted(sorted_arr) {|first, second| assert_true(first.wheels <= second.wheels, "Cars not sorted: #{first.wheels} wheels is not >= #{second.wheels} wheels")}
       end
     end
   end

--- a/test/utils/car.rb
+++ b/test/utils/car.rb
@@ -1,0 +1,13 @@
+class Car
+  include Comparable
+
+  attr_reader :wheels
+
+  def initialize(wheels = rand(1...1000))
+    @wheels = wheels
+  end
+
+  def <=>(other)
+    @wheels <=> other.wheels
+  end
+end


### PR DESCRIPTION
`ConcurrentSort::sort` now accepts an optional block. 

To maintain consistency with Ruby,
> the block must implement a comparison between a and b and return an integer less than 0 when b follows a, 0 when a and b are equivalent, or an integer greater than 0 when a follows b.

see https://ruby-doc.org/core-2.5.0/Array.html#method-i-sort.

closes #5 