### PR TITLE
Required threads calculation

### DIFF
--- a/lib/concurrent_sort.rb
+++ b/lib/concurrent_sort.rb
@@ -3,16 +3,13 @@ require_relative 'merge_sort_concurrent'
 module ConcurrentSort
   extend self
 
-  FAN_OUT = 200
-  MIN = 1000
-
   def stream_sort
 
   end
 
   def sort(data)
     result_buf = []
-    MergeSortConcurrent.new(FAN_OUT, MIN, data, result_buf).sort
+    MergeSortConcurrent.new(data, result_buf).sort
     result_buf
   end
 end

--- a/lib/concurrent_sort.rb
+++ b/lib/concurrent_sort.rb
@@ -12,7 +12,7 @@ module ConcurrentSort
   # See: https://ruby-doc.org/core-2.5.0/Array.html#method-i-sort
   def sort(data)
     result_buf = []
-    MergeSortConcurrent.new(data, result_buf).sort
+    MergeSortConcurrent.new(data, result_buf, block_given? ? Proc.new : nil).sort
     result_buf
   end
 end

--- a/test/merge_sort_test.rb
+++ b/test/merge_sort_test.rb
@@ -1,5 +1,6 @@
 require 'test/unit'
 require_relative '../lib/concurrent_sort'
+require_relative '../lib/merge_sort_concurrent'
 require_relative 'utils/car'
 
 class MergeSortTest < Test::Unit::TestCase
@@ -79,6 +80,25 @@ class MergeSortTest < Test::Unit::TestCase
       # Postconditions
       begin
         assert_sorted(sorted_arr) {|first, second| assert_true(first.wheels <= second.wheels, "Cars not sorted: #{first.wheels} wheels is not >= #{second.wheels} wheels")}
+      end
+    end
+  end
+
+  def test_too_many_threads
+    (0..TEST_ITER).each do
+      arr = rand_int_array(size: MAX_LEN)
+      fan_out = 2
+      threshold = 1
+
+      # Preconditions
+      begin
+        assert_true(MergeSortConcurrent.num_threads(arr.length, fan_out, threshold) > MergeSortConcurrent::MAX_THREADS)
+      end
+
+      assert_raise(MergeSortConcurrent::InvalidSortConfiguration) { MergeSortConcurrent.new(arr, [], fan_out: fan_out, min: threshold)}
+
+      # Postconditions
+      begin
       end
     end
   end


### PR DESCRIPTION
Calculate the required number of threads given the fanout/single-thread-threshold and ensure it is less than `MAX_THREADS` -- associated test added.

closes #17 